### PR TITLE
GH-879 Bug in file PHPExcel/Reader/CSV.php

### DIFF
--- a/src/PhpSpreadsheet/Reader/CSV.php
+++ b/src/PhpSpreadsheet/Reader/CSV.php
@@ -163,10 +163,11 @@ class CSV extends BaseReader implements IReader
             return;
         }
 
-        if ((strlen(trim($line)) == 5) && (strpos($line, 'sep=') !== 0)) {
-            return $this->skipBOM();
+        if ((strlen(trim($line, "\r\n")) == 5) && (stripos($line, 'sep=') === 0)) {
+            $this->delimiter = substr($line, 4, 1);
+            return;
         }
-        $this->delimiter = substr($line, 4, 1);
+        return $this->skipBOM();
     }
 
     /**


### PR DESCRIPTION
Code logic identifying a defined separator when no separator is explicitly defined
Case-insensitive check when separator is explicitly defined